### PR TITLE
feat: add staff renter management view

### DIFF
--- a/src/app/core-logic/renters/renters.service.ts
+++ b/src/app/core-logic/renters/renters.service.ts
@@ -1,0 +1,88 @@
+import { inject, Injectable, signal } from '@angular/core';
+import { catchError, finalize, map, Observable, of, tap } from 'rxjs';
+import { RenterProfileDto, StaffService } from '../../../contract';
+
+export interface StaffRenterRecord {
+  readonly renterId: string;
+  readonly name: string;
+  readonly driverLicense?: string;
+  readonly dateOfBirth?: string;
+  readonly address?: string;
+  readonly riskScore?: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class RentersService {
+  private readonly _staffService = inject(StaffService);
+
+  private readonly _staffRenters = signal<StaffRenterRecord[]>([]);
+  private readonly _loading = signal(false);
+  private readonly _error = signal<string | null>(null);
+
+  readonly staffRenters = this._staffRenters.asReadonly();
+  readonly staffRentersLoading = this._loading.asReadonly();
+  readonly staffRentersError = this._error.asReadonly();
+
+  loadStaffRenters(): Observable<StaffRenterRecord[]> {
+    this._loading.set(true);
+    this._error.set(null);
+
+    return this._staffService.apiStaffRentersGet().pipe(
+      map((response) => this._mapRenters(response.data ?? [])),
+      tap((records) => {
+        this._staffRenters.set(records);
+        this._error.set(null);
+      }),
+      catchError((error: unknown) => {
+        this._error.set(this._resolveErrorMessage(error));
+        const fallback = [...this._staffRenters()];
+        return of(fallback);
+      }),
+      finalize(() => {
+        this._loading.set(false);
+      }),
+    );
+  }
+
+  private _mapRenters(renters: readonly (RenterProfileDto | null)[]): StaffRenterRecord[] {
+    const records: StaffRenterRecord[] = [];
+
+    for (const renter of renters) {
+      if (!renter) {
+        continue;
+      }
+
+      const renterId = this._normalizeString(renter.renterId);
+      if (!renterId) {
+        continue;
+      }
+
+      const name =
+        this._normalizeString(renter.userName) ?? `Renter ${renterId.slice(-5).toUpperCase()}`;
+
+      records.push({
+        renterId,
+        name,
+        driverLicense: this._normalizeString(renter.driverLicenseNo),
+        dateOfBirth: this._normalizeString(renter.dateOfBirth),
+        address: this._normalizeString(renter.address),
+        riskScore: typeof renter.riskScore === 'number' ? renter.riskScore : undefined,
+      });
+    }
+
+    return records.sort((first, second) => first.name.localeCompare(second.name));
+  }
+
+  private _normalizeString(value: string | null | undefined): string | undefined {
+    const trimmed = value?.trim();
+    return trimmed ? trimmed : undefined;
+  }
+
+  private _resolveErrorMessage(error: unknown): string {
+    if (error instanceof Error && error.message) {
+      return error.message;
+    }
+
+    return 'Unable to load renters. Please try again later.';
+  }
+}

--- a/src/app/features/staff/renter-management/renter-management.html
+++ b/src/app/features/staff/renter-management/renter-management.html
@@ -1,0 +1,223 @@
+<section class="renter-management">
+  <header class="page-header">
+    <div class="page-header__titles">
+      <h1 class="page-header__title">Renter Management</h1>
+      <p class="page-header__subtitle">
+        Review renter profiles, assess risk scores, and verify licensing details.
+      </p>
+    </div>
+    <button type="button" class="refresh-button" (click)="refresh()" [disabled]="loading()">
+      <mat-icon aria-hidden="true">refresh</mat-icon>
+      <span>Refresh</span>
+    </button>
+  </header>
+
+  <div class="toolbar" aria-label="Renter tools">
+    <div class="toolbar__search">
+      <mat-icon aria-hidden="true">search</mat-icon>
+      <input
+        type="search"
+        class="toolbar__input"
+        [value]="searchTerm()"
+        (input)="onSearchInput($event)"
+        placeholder="Search renter name, ID, or license"
+        autocomplete="off"
+      />
+      @if (searchTerm()) {
+        <button
+          type="button"
+          class="toolbar__clear"
+          (click)="clearSearch()"
+          aria-label="Clear search"
+        >
+          <mat-icon aria-hidden="true">close</mat-icon>
+        </button>
+      }
+    </div>
+
+    <div class="toolbar__filters" role="group" aria-label="Risk filters">
+      @for (filter of filters; track filter.key) {
+        <button
+          type="button"
+          class="filter-chip"
+          [class.filter-chip--active]="riskFilter() === filter.key"
+          (click)="setRiskFilter(filter.key)"
+        >
+          <span class="filter-chip__label">{{ filter.label }}</span>
+          <span class="filter-chip__description">{{ filter.description }}</span>
+        </button>
+      }
+    </div>
+
+    <div class="toolbar__actions" aria-label="View options">
+      <span class="toolbar__count" aria-live="polite">{{ filteredCount() }} renters</span>
+      <button
+        type="button"
+        class="icon-button"
+        (click)="setViewMode('list')"
+        [class.icon-button--active]="viewMode() === 'list'"
+        aria-label="List view"
+      >
+        <mat-icon aria-hidden="true">view_list</mat-icon>
+      </button>
+      <button
+        type="button"
+        class="icon-button"
+        (click)="setViewMode('grid')"
+        [class.icon-button--active]="viewMode() === 'grid'"
+        aria-label="Grid view"
+      >
+        <mat-icon aria-hidden="true">grid_view</mat-icon>
+      </button>
+    </div>
+  </div>
+
+  @if (error()) {
+    <div class="alert alert--error" role="alert">
+      <div class="alert__content">
+        <mat-icon aria-hidden="true">error</mat-icon>
+        <span>{{ error() }}</span>
+      </div>
+      <button type="button" class="alert__action" (click)="refresh()">Retry</button>
+    </div>
+  }
+
+  @if (loading()) {
+    <div class="loading-state" aria-live="polite">
+      <div class="loading-state__spinner"></div>
+      <p>Loading renters...</p>
+    </div>
+  } @else {
+    @if (cardViewModels().length > 0) {
+      <div class="renter-collection" [class.renter-collection--list]="viewMode() === 'list'">
+        @for (card of cardViewModels(); track card.identifier) {
+          <article class="renter-card">
+            <header class="renter-card__header">
+              <div>
+                <p class="renter-card__identifier">ID: {{ card.identifier }}</p>
+                <h3 class="renter-card__title">{{ card.name }}</h3>
+              </div>
+              @if (card.riskBadge) {
+                <span
+                  class="badge"
+                  [class.badge--success]="card.riskBadge.tone === 'success'"
+                  [class.badge--info]="card.riskBadge.tone === 'info'"
+                  [class.badge--danger]="card.riskBadge.tone === 'danger'"
+                  [class.badge--pending]="card.riskBadge.tone === 'pending'"
+                >
+                  {{ card.riskBadge.text }}
+                </span>
+              }
+            </header>
+
+            <dl class="renter-card__details">
+              <div class="renter-card__row">
+                <dt>License</dt>
+                <dd>{{ card.licenseDisplay }}</dd>
+              </div>
+              <div class="renter-card__row">
+                <dt>Address</dt>
+                <dd>{{ card.locationDisplay }}</dd>
+              </div>
+              <div class="renter-card__row">
+                <dt>Date of birth</dt>
+                <dd>{{ card.dateOfBirthDisplay }}</dd>
+              </div>
+              <div class="renter-card__row">
+                <dt>Risk score</dt>
+                <dd>{{ card.riskScoreDisplay }}</dd>
+              </div>
+            </dl>
+
+            <footer class="renter-card__footer">
+              <button
+                type="button"
+                class="renter-card__cta"
+                (click)="openDetails(card.record, $event)"
+              >
+                View profile
+              </button>
+            </footer>
+          </article>
+        }
+      </div>
+    } @else {
+      <div class="empty-state">
+        <mat-icon aria-hidden="true">sentiment_satisfied</mat-icon>
+        <h2>No renters found</h2>
+        <p>Try adjusting the risk filters or clearing the search.</p>
+        <button type="button" (click)="clearSearch()">Clear search</button>
+      </div>
+    }
+  }
+
+  @if (selectedRenterView(); as detail) {
+    <div
+      class="details-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="renter-details-title"
+      aria-describedby="renter-details-summary"
+      (click)="onOverlayClick($event)"
+      (keydown.escape)="closeDetails()"
+    >
+      <div #detailPanel class="details-panel" tabindex="-1">
+        <header class="details-panel__header">
+          <div>
+            <h2 id="renter-details-title">Renter profile</h2>
+            <p id="renter-details-summary">{{ detail.name }}</p>
+          </div>
+          <button type="button" class="details-panel__close" (click)="closeDetails()">
+            <mat-icon aria-hidden="true">close</mat-icon>
+            <span class="sr-only">Close dialog</span>
+          </button>
+        </header>
+
+        <div class="details-panel__body">
+          <section class="details-section">
+            <h3>Identity</h3>
+            <dl>
+              <div>
+                <dt>Renter ID</dt>
+                <dd>{{ detail.renterId }}</dd>
+              </div>
+              <div>
+                <dt>Driver license</dt>
+                <dd>{{ detail.driverLicense ?? 'No license on file' }}</dd>
+              </div>
+              <div>
+                <dt>Date of birth</dt>
+                <dd>{{ detail.dateOfBirth ?? 'Unavailable' }}</dd>
+              </div>
+              <div>
+                <dt>Address</dt>
+                <dd>{{ detail.address ?? 'Not provided' }}</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section class="details-section">
+            <h3>Risk assessment</h3>
+            <div class="risk-summary">
+              @if (detail.riskBadge) {
+                <span
+                  class="badge"
+                  [class.badge--success]="detail.riskBadge.tone === 'success'"
+                  [class.badge--info]="detail.riskBadge.tone === 'info'"
+                  [class.badge--danger]="detail.riskBadge.tone === 'danger'"
+                  [class.badge--pending]="detail.riskBadge.tone === 'pending'"
+                >
+                  {{ detail.riskBadge.text }}
+                </span>
+              }
+              <p class="risk-summary__score">
+                Risk score: {{ detail.riskScore !== undefined ? detail.riskScore : 'Unknown' }}
+              </p>
+              <p class="risk-summary__description">{{ detail.riskDescription }}</p>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  }
+</section>

--- a/src/app/features/staff/renter-management/renter-management.scss
+++ b/src/app/features/staff/renter-management/renter-management.scss
@@ -1,0 +1,494 @@
+:host {
+  display: block;
+  padding: 2.5rem 0;
+  color: var(--mat-sys-on-surface, #0f172a);
+}
+
+.renter-management {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.page-header__titles {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.page-header__title {
+  margin: 0;
+  font-size: clamp(1.75rem, 2vw, 2rem);
+  font-weight: 600;
+}
+
+.page-header__subtitle {
+  margin: 0;
+  color: var(--mat-sys-on-surface-variant, #4b5563);
+  font-size: 0.95rem;
+}
+
+.refresh-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.2rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: var(--mat-sys-primary, #2563eb);
+  color: var(--mat-sys-on-primary, #fff);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.refresh-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.refresh-button:hover:enabled {
+  background: color-mix(in srgb, var(--mat-sys-primary, #2563eb) 88%, #fff);
+  box-shadow: 0 8px 16px rgb(37 99 235 / 25%);
+  transform: translateY(-1px);
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.toolbar__search {
+  position: relative;
+  flex: 1 1 320px;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  background: var(--mat-sys-surface-container-high, #f1f5f9);
+}
+
+.toolbar__search mat-icon {
+  color: var(--mat-sys-on-surface-variant, #64748b);
+}
+
+.toolbar__input {
+  flex: 1 1 auto;
+  border: 0;
+  background: transparent;
+  font-size: 0.95rem;
+  color: inherit;
+}
+
+.toolbar__input:focus {
+  outline: none;
+}
+
+.toolbar__clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--mat-sys-on-surface-variant, #64748b);
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.toolbar__clear:hover {
+  background: rgb(148 163 184 / 20%);
+}
+
+.toolbar__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.filter-chip {
+  display: grid;
+  gap: 0.15rem;
+  padding: 0.5rem 0.9rem;
+  border: 1px solid var(--mat-sys-outline-variant, #d1d5db);
+  border-radius: 0.75rem;
+  background: #fff;
+  min-width: 9rem;
+  cursor: pointer;
+  transition: border 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  text-align: left;
+}
+
+.filter-chip:hover {
+  border-color: var(--mat-sys-primary, #2563eb);
+  box-shadow: 0 8px 16px rgb(37 99 235 / 12%);
+  transform: translateY(-1px);
+}
+
+.filter-chip--active {
+  border-color: var(--mat-sys-primary, #2563eb);
+  background: rgb(37 99 235 / 10%);
+}
+
+.filter-chip__label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.filter-chip__description {
+  font-size: 0.8rem;
+  color: var(--mat-sys-on-surface-variant, #64748b);
+}
+
+.toolbar__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.toolbar__count {
+  font-size: 0.85rem;
+  color: var(--mat-sys-on-surface-variant, #475569);
+}
+
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--mat-sys-on-surface-variant, #475569);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.icon-button:hover {
+  background: rgb(148 163 184 / 16%);
+}
+
+.icon-button--active {
+  background: rgb(37 99 235 / 12%);
+  color: var(--mat-sys-primary, #2563eb);
+}
+
+.alert {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 1.2rem;
+  border-radius: 0.75rem;
+}
+
+.alert--error {
+  background: rgb(239 68 68 / 12%);
+  color: #b91c1c;
+}
+
+.alert__content {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.alert__action {
+  border: 0;
+  background: transparent;
+  color: var(--mat-sys-primary, #2563eb);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.loading-state {
+  display: grid;
+  gap: 0.75rem;
+  place-items: center;
+  padding: 3rem 0;
+  color: var(--mat-sys-on-surface-variant, #64748b);
+}
+
+.loading-state__spinner {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  border: 3px solid rgb(37 99 235 / 20%);
+  border-top-color: var(--mat-sys-primary, #2563eb);
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.renter-collection {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+
+.renter-collection--list {
+  grid-template-columns: 1fr;
+}
+
+.renter-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  background: #fff;
+  box-shadow: 0 10px 30px rgb(15 23 42 / 6%);
+}
+
+.renter-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.renter-card__identifier {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--mat-sys-on-surface-variant, #64748b);
+}
+
+.renter-card__title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.renter-card__details {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.renter-card__row {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.renter-card__row dt {
+  font-size: 0.75rem;
+  color: var(--mat-sys-on-surface-variant, #64748b);
+}
+
+.renter-card__row dd {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--mat-sys-on-surface, #111827);
+}
+
+.renter-card__footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.renter-card__cta {
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: 0;
+  background: var(--mat-sys-primary, #2563eb);
+  color: var(--mat-sys-on-primary, #fff);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.renter-card__cta:hover {
+  background: color-mix(in srgb, var(--mat-sys-primary, #2563eb) 88%, #fff);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.badge--success {
+  background: rgb(34 197 94 / 18%);
+  color: #047857;
+}
+
+.badge--info {
+  background: rgb(59 130 246 / 18%);
+  color: #1d4ed8;
+}
+
+.badge--danger {
+  background: rgb(248 113 113 / 18%);
+  color: #b91c1c;
+}
+
+.badge--pending {
+  background: rgb(234 179 8 / 18%);
+  color: #b45309;
+}
+
+.empty-state {
+  display: grid;
+  place-items: center;
+  gap: 0.75rem;
+  padding: 3rem 1rem;
+  text-align: center;
+  background: #fff;
+  border-radius: 1rem;
+  box-shadow: inset 0 0 0 1px rgb(148 163 184 / 16%);
+}
+
+.empty-state mat-icon {
+  font-size: 2.5rem;
+  color: var(--mat-sys-primary, #2563eb);
+}
+
+.details-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgb(15 23 42 / 45%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+  z-index: 50;
+}
+
+.details-panel {
+  width: min(520px, 100%);
+  max-height: 90vh;
+  overflow-y: auto;
+  background: #fff;
+  border-radius: 1rem;
+  box-shadow: 0 24px 48px rgb(15 23 42 / 18%);
+  padding: 1.5rem;
+  outline: none;
+}
+
+.details-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.details-panel__header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.details-panel__header p {
+  margin: 0;
+  color: var(--mat-sys-on-surface-variant, #64748b);
+}
+
+.details-panel__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 999px;
+  border: 0;
+  background: rgb(148 163 184 / 16%);
+  color: var(--mat-sys-on-surface, #0f172a);
+  cursor: pointer;
+}
+
+.details-panel__body {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.details-section h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.details-section dl {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.details-section dl div {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.details-section dt {
+  font-size: 0.8rem;
+  color: var(--mat-sys-on-surface-variant, #64748b);
+}
+
+.details-section dd {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.risk-summary {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.risk-summary__score {
+  margin: 0;
+  font-weight: 600;
+}
+
+.risk-summary__description {
+  margin: 0;
+  color: var(--mat-sys-on-surface-variant, #475569);
+  font-size: 0.95rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 768px) {
+  .toolbar {
+    align-items: stretch;
+  }
+
+  .toolbar__actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .filter-chip {
+    flex: 1 1 calc(50% - 0.75rem);
+  }
+}

--- a/src/app/features/staff/renter-management/renter-management.scss
+++ b/src/app/features/staff/renter-management/renter-management.scss
@@ -62,7 +62,7 @@
 .toolbar {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
 }
@@ -70,6 +70,7 @@
 .toolbar__search {
   position: relative;
   flex: 1 1 320px;
+  max-width: 420px;
   display: flex;
   align-items: center;
   gap: 0.75rem;
@@ -114,9 +115,10 @@
 
 .toolbar__filters {
   display: flex;
+  flex: 1 1 420px;
   flex-wrap: wrap;
   gap: 0.75rem;
-  justify-content: center;
+  justify-content: flex-start;
 }
 
 .filter-chip {
@@ -259,10 +261,14 @@
 }
 
 .renter-card__header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: start;
   gap: 0.75rem;
+}
+
+.renter-card__header .badge {
+  justify-self: end;
 }
 
 .renter-card__identifier {
@@ -481,6 +487,15 @@
 @media (max-width: 768px) {
   .toolbar {
     align-items: stretch;
+  }
+
+  .toolbar__search {
+    max-width: none;
+  }
+
+  .toolbar__filters {
+    flex: 1 1 100%;
+    justify-content: space-between;
   }
 
   .toolbar__actions {

--- a/src/app/features/staff/renter-management/renter-management.ts
+++ b/src/app/features/staff/renter-management/renter-management.ts
@@ -1,0 +1,272 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  ViewChild,
+  afterNextRender,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { take } from 'rxjs';
+import { RentersService, StaffRenterRecord } from '../../../core-logic/renters/renters.service';
+
+interface RiskFilterDescriptor {
+  readonly key: RiskFilterKey;
+  readonly label: string;
+  readonly description: string;
+}
+
+type RiskFilterKey = 'all' | 'low' | 'medium' | 'high';
+
+type RiskLevel = 'low' | 'medium' | 'high' | 'unknown';
+
+type StatusTone = 'pending' | 'success' | 'danger' | 'info';
+
+interface StatusBadge {
+  readonly text: string;
+  readonly tone: StatusTone;
+}
+
+interface RenterCardViewModel {
+  readonly record: StaffRenterRecord;
+  readonly name: string;
+  readonly identifier: string;
+  readonly licenseDisplay: string;
+  readonly locationDisplay: string;
+  readonly dateOfBirthDisplay: string;
+  readonly riskScoreDisplay: string;
+  readonly riskBadge?: StatusBadge;
+}
+
+interface SelectedRenterViewModel {
+  readonly record: StaffRenterRecord;
+  readonly name: string;
+  readonly renterId: string;
+  readonly driverLicense?: string;
+  readonly address?: string;
+  readonly dateOfBirth?: string;
+  readonly riskScore?: number;
+  readonly riskBadge?: StatusBadge;
+  readonly riskDescription: string;
+}
+
+const RISK_FILTERS: readonly RiskFilterDescriptor[] = [
+  { key: 'all', label: 'All renters', description: 'Include every risk level' },
+  { key: 'low', label: 'Low risk', description: 'Score 0 – 40' },
+  { key: 'medium', label: 'Medium risk', description: 'Score 41 – 70' },
+  { key: 'high', label: 'High risk', description: 'Score 71 – 100' },
+] as const;
+
+const RISK_BADGES: Record<RiskLevel, StatusBadge | undefined> = {
+  low: { text: 'Low risk', tone: 'success' },
+  medium: { text: 'Medium risk', tone: 'info' },
+  high: { text: 'High risk', tone: 'danger' },
+  unknown: undefined,
+};
+
+@Component({
+  selector: 'app-renter-management',
+  imports: [MatIconModule],
+  templateUrl: './renter-management.html',
+  styleUrl: './renter-management.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RenterManagement {
+  private readonly rentersService = inject(RentersService);
+  @ViewChild('detailPanel') private detailPanel?: ElementRef<HTMLDivElement>;
+  private activeDetailTrigger: HTMLElement | null = null;
+
+  readonly filters = RISK_FILTERS;
+  readonly searchTerm = signal('');
+  readonly riskFilter = signal<RiskFilterKey>('all');
+  readonly viewMode = signal<'grid' | 'list'>('grid');
+  readonly selectedRenter = signal<StaffRenterRecord | null>(null);
+
+  readonly loading = computed(() => this.rentersService.staffRentersLoading());
+  readonly error = computed(() => this.rentersService.staffRentersError());
+  private readonly allRenters = computed(() => this.rentersService.staffRenters());
+  private readonly normalizedSearch = computed(() => this.searchTerm().trim().toLowerCase());
+
+  private readonly filteredRenters = computed(() => {
+    const query = this.normalizedSearch();
+    const filter = this.riskFilter();
+
+    return this.allRenters().filter(
+      (record) => this._matchesSearch(record, query) && this._matchesRisk(record, filter),
+    );
+  });
+
+  readonly filteredCount = computed(() => this.filteredRenters().length);
+
+  readonly cardViewModels = computed<RenterCardViewModel[]>(() =>
+    this.filteredRenters().map((record) => {
+      const riskLevel = this._determineRiskLevel(record.riskScore);
+      const badge = RISK_BADGES[riskLevel];
+      return {
+        record,
+        name: record.name,
+        identifier: record.renterId,
+        licenseDisplay: record.driverLicense ?? 'No license on file',
+        locationDisplay: record.address ?? 'Address not provided',
+        dateOfBirthDisplay: this._formatDate(record.dateOfBirth) ?? 'Date of birth unavailable',
+        riskScoreDisplay:
+          typeof record.riskScore === 'number' ? `${Math.round(record.riskScore)} pts` : 'Unknown',
+        riskBadge: badge,
+      } satisfies RenterCardViewModel;
+    }),
+  );
+
+  readonly selectedRenterView = computed<SelectedRenterViewModel | null>(() => {
+    const record = this.selectedRenter();
+    if (!record) {
+      return null;
+    }
+
+    const riskLevel = this._determineRiskLevel(record.riskScore);
+    return {
+      record,
+      name: record.name,
+      renterId: record.renterId,
+      driverLicense: record.driverLicense,
+      address: record.address,
+      dateOfBirth: this._formatDate(record.dateOfBirth) ?? undefined,
+      riskScore: record.riskScore,
+      riskBadge: RISK_BADGES[riskLevel],
+      riskDescription: this._describeRisk(riskLevel),
+    } satisfies SelectedRenterViewModel;
+  });
+
+  private readonly dateFormatter = new Intl.DateTimeFormat('vi-VN', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+
+  constructor() {
+    this.refresh();
+  }
+
+  refresh(): void {
+    this.rentersService.loadStaffRenters().pipe(take(1)).subscribe();
+  }
+
+  onSearchInput(event: Event): void {
+    const target = event.target as HTMLInputElement | null;
+    this.searchTerm.set(target?.value ?? '');
+  }
+
+  clearSearch(): void {
+    if (this.searchTerm().length === 0) {
+      return;
+    }
+
+    this.searchTerm.set('');
+  }
+
+  setRiskFilter(filter: RiskFilterKey): void {
+    if (this.riskFilter() === filter) {
+      return;
+    }
+
+    this.riskFilter.set(filter);
+  }
+
+  setViewMode(mode: 'grid' | 'list'): void {
+    if (this.viewMode() === mode) {
+      return;
+    }
+
+    this.viewMode.set(mode);
+  }
+
+  openDetails(record: StaffRenterRecord, triggerEvent?: Event): void {
+    this.activeDetailTrigger =
+      triggerEvent?.currentTarget instanceof HTMLElement ? triggerEvent.currentTarget : null;
+    this.selectedRenter.set(record);
+    afterNextRender(() => {
+      this.detailPanel?.nativeElement.focus();
+    });
+  }
+
+  closeDetails(): void {
+    this.selectedRenter.set(null);
+    const target = this.activeDetailTrigger;
+    this.activeDetailTrigger = null;
+    if (target) {
+      queueMicrotask(() => {
+        target.focus();
+      });
+    }
+  }
+
+  onOverlayClick(event: MouseEvent): void {
+    if (event.target === event.currentTarget) {
+      this.closeDetails();
+    }
+  }
+
+  private _matchesSearch(record: StaffRenterRecord, query: string): boolean {
+    if (!query) {
+      return true;
+    }
+
+    const haystacks = [record.name, record.renterId, record.driverLicense, record.address]
+      .map((value) => value?.toLowerCase() ?? '')
+      .filter((value) => value.length > 0);
+
+    return haystacks.some((value) => value.includes(query));
+  }
+
+  private _matchesRisk(record: StaffRenterRecord, filter: RiskFilterKey): boolean {
+    if (filter === 'all') {
+      return true;
+    }
+
+    const level = this._determineRiskLevel(record.riskScore);
+    return level === filter;
+  }
+
+  private _determineRiskLevel(score: number | undefined): RiskLevel {
+    if (typeof score !== 'number' || Number.isNaN(score)) {
+      return 'unknown';
+    }
+
+    if (score <= 40) {
+      return 'low';
+    }
+
+    if (score <= 70) {
+      return 'medium';
+    }
+
+    return 'high';
+  }
+
+  private _describeRisk(level: RiskLevel): string {
+    switch (level) {
+      case 'low':
+        return 'The renter has a low risk score, indicating consistent compliance with rental policies.';
+      case 'medium':
+        return 'The renter has a moderate risk score. Consider reviewing recent rental history before approval.';
+      case 'high':
+        return 'The renter has a high risk score and may require additional verification before proceeding.';
+      default:
+        return 'Risk information is not available for this renter.';
+    }
+  }
+
+  private _formatDate(isoString: string | undefined): string | null {
+    if (!isoString) {
+      return null;
+    }
+
+    const date = new Date(isoString);
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+
+    return this.dateFormatter.format(date);
+  }
+}

--- a/src/app/features/staff/staff.routes.ts
+++ b/src/app/features/staff/staff.routes.ts
@@ -1,6 +1,8 @@
 import { Routes } from '@angular/router';
 import { StaffDashboard } from './staff-dashboard/staff-dashboard';
 import { RentalManagement } from './rental-management/rental-management';
+import { RenterManagement } from './renter-management/renter-management';
+import { VehicleManagement } from './vehicle-management/vehicle-management';
 
 export default [
   {
@@ -11,6 +13,19 @@ export default [
   {
     path: 'bookings',
     component: StaffDashboard,
+  },
+  {
+    path: 'vehicles',
+    component: VehicleManagement,
+  },
+  {
+    path: 'customers',
+    pathMatch: 'full',
+    redirectTo: 'renters',
+  },
+  {
+    path: 'renters',
+    component: RenterManagement,
   },
   {
     path: 'rentals',

--- a/src/app/layout/layout.ts
+++ b/src/app/layout/layout.ts
@@ -86,17 +86,17 @@ export class LayoutComponent {
     ],
     staff: [
       { name: 'Booking Management', href: '/staff/bookings', current: false, icon: 'event_note' },
-      { name: 'Quản lý xe', href: '/staff/vehicles', current: false, icon: 'car_rental' },
-      { name: 'Quản lý người thuê', href: '/staff/renters', current: false, icon: 'group' },
+      { name: 'Vehicles Management', href: '/staff/vehicles', current: false, icon: 'car_rental' },
+      { name: 'Renter Management', href: '/staff/renters', current: false, icon: 'group' },
       { name: 'Rental Management', href: '/staff/rentals', current: false, icon: 'assignment' },
-      { name: 'Báo cáo', href: '/staff/reports', current: false, icon: 'analytics' },
+      { name: 'Reports', href: '/staff/reports', current: false, icon: 'analytics' },
     ],
     admin: [
-      { name: 'Quản lý người dùng', href: '/admin/users', current: false, icon: 'group' },
-      { name: 'Quản lý xe', href: '/admin/vehicles', current: false, icon: 'car_rental' },
-      { name: 'Quản lý đơn thuê', href: '/admin/orders', current: false, icon: 'assignment' },
-      { name: 'Báo cáo', href: '/admin/reports', current: false, icon: 'analytics' },
-      { name: 'Cài đặt hệ thống', href: '/admin/settings', current: false, icon: 'settings' },
+      { name: 'User Management', href: '/admin/users', current: false, icon: 'group' },
+      { name: 'Vehicle Management', href: '/admin/vehicles', current: false, icon: 'car_rental' },
+      { name: 'Rental Management', href: '/admin/orders', current: false, icon: 'assignment' },
+      { name: 'Reports', href: '/admin/reports', current: false, icon: 'analytics' },
+      { name: 'System Settings', href: '/admin/settings', current: false, icon: 'settings' },
     ],
   };
 

--- a/src/app/layout/layout.ts
+++ b/src/app/layout/layout.ts
@@ -87,7 +87,7 @@ export class LayoutComponent {
     staff: [
       { name: 'Booking Management', href: '/staff/bookings', current: false, icon: 'event_note' },
       { name: 'Quản lý xe', href: '/staff/vehicles', current: false, icon: 'car_rental' },
-      { name: 'Quản lý khách hàng', href: '/staff/customers', current: false, icon: 'group' },
+      { name: 'Quản lý người thuê', href: '/staff/renters', current: false, icon: 'group' },
       { name: 'Rental Management', href: '/staff/rentals', current: false, icon: 'assignment' },
       { name: 'Báo cáo', href: '/staff/reports', current: false, icon: 'analytics' },
     ],


### PR DESCRIPTION
## Summary
- add a renter data service that pulls staff renter profiles from the staff API
- build a renter management screen with search, risk filters, and profile details for staff
- register the renters route and update staff navigation to point at it

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691355eb952c8320b716c22c613e30b4)