### PR TITLE
feat: add staff renters management feature

### DIFF
--- a/src/app/core-logic/renters/renters.service.ts
+++ b/src/app/core-logic/renters/renters.service.ts
@@ -1,0 +1,98 @@
+import { inject, Injectable, signal } from '@angular/core';
+import { RenterProfileDto, RenterProfileDtoListApiResponse, StaffService } from '../../../contract';
+import { catchError, finalize, map, Observable, of, tap } from 'rxjs';
+
+export interface StaffRenterRecord {
+  readonly renterId: string;
+  readonly userName?: string;
+  readonly driverLicenseNo?: string;
+  readonly dateOfBirth?: string;
+  readonly address?: string;
+  readonly riskScore?: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class RentersService {
+  private readonly _staffService = inject(StaffService);
+
+  private readonly _renters = signal<StaffRenterRecord[]>([]);
+  private readonly _loading = signal(false);
+  private readonly _error = signal<string | null>(null);
+
+  readonly staffRenters = this._renters.asReadonly();
+  readonly staffRentersLoading = this._loading.asReadonly();
+  readonly staffRentersError = this._error.asReadonly();
+
+  loadStaffRenters(): Observable<StaffRenterRecord[]> {
+    this._loading.set(true);
+    this._error.set(null);
+
+    return this._staffService.apiStaffRentersGet().pipe(
+      map((response: RenterProfileDtoListApiResponse) => {
+        const renterItems = response.data ?? [];
+        return this._mapRenters(renterItems);
+      }),
+      tap((records) => {
+        this._renters.set(records);
+        this._error.set(null);
+      }),
+      catchError((error: unknown) => {
+        this._error.set(this._resolveErrorMessage(error));
+        const fallback = [...this._renters()];
+        return of(fallback);
+      }),
+      finalize(() => {
+        this._loading.set(false);
+      }),
+    );
+  }
+
+  private _mapRenters(
+    renters: readonly (RenterProfileDto | null | undefined)[],
+  ): StaffRenterRecord[] {
+    const records: StaffRenterRecord[] = [];
+
+    for (const renter of renters) {
+      if (!renter) {
+        continue;
+      }
+
+      const renterId = this._normalizeString(renter.renterId);
+      if (!renterId) {
+        continue;
+      }
+
+      records.push({
+        renterId,
+        userName: this._normalizeString(renter.userName ?? undefined),
+        driverLicenseNo: this._normalizeString(renter.driverLicenseNo ?? undefined),
+        dateOfBirth: this._normalizeString(renter.dateOfBirth ?? undefined),
+        address: this._normalizeString(renter.address ?? undefined),
+        riskScore: renter.riskScore ?? undefined,
+      });
+    }
+
+    return records.sort((first, second) => first.renterId.localeCompare(second.renterId));
+  }
+
+  private _normalizeString(value: string | null | undefined): string | undefined {
+    if (!value) {
+      return undefined;
+    }
+
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  private _resolveErrorMessage(error: unknown): string {
+    if (error instanceof Error && error.message) {
+      return error.message;
+    }
+
+    if (typeof error === 'string' && error.length > 0) {
+      return error;
+    }
+
+    return 'Không thể tải danh sách khách thuê. Vui lòng thử lại sau.';
+  }
+}

--- a/src/app/features/staff/renter-management/renter-management.html
+++ b/src/app/features/staff/renter-management/renter-management.html
@@ -1,0 +1,126 @@
+<section class="renter-management">
+  <header class="page-header">
+    <div class="page-header__titles">
+      <h1 class="page-header__title">Renters Management</h1>
+      <p class="page-header__subtitle">
+        Theo dõi hồ sơ khách thuê, điểm rủi ro và thông tin liên hệ để hỗ trợ vận hành.
+      </p>
+    </div>
+    <button type="button" class="refresh-button" (click)="refresh()" [disabled]="loading()">
+      <mat-icon aria-hidden="true">refresh</mat-icon>
+      <span>Làm mới</span>
+    </button>
+  </header>
+
+  <div class="toolbar">
+    <div class="toolbar__search">
+      <mat-icon aria-hidden="true">search</mat-icon>
+      <input
+        type="search"
+        class="toolbar__input"
+        [value]="searchTerm()"
+        (input)="onSearchInput($event)"
+        placeholder="Tìm kiếm tên, mã khách hoặc số bằng lái"
+        autocomplete="off"
+      />
+      @if (searchTerm()) {
+        <button
+          type="button"
+          class="toolbar__clear"
+          (click)="clearSearch()"
+          aria-label="Xóa tìm kiếm"
+        >
+          <mat-icon aria-hidden="true">close</mat-icon>
+        </button>
+      }
+    </div>
+
+    <div class="toolbar__filters" aria-label="Lọc theo mức độ rủi ro">
+      @for (filter of riskFilters; track filter.key) {
+        <button
+          type="button"
+          class="filter-chip"
+          [class.filter-chip--active]="riskFilter() === filter.key"
+          (click)="onRiskFilterChange(filter.key)"
+        >
+          <span class="filter-chip__label">{{ filter.label }}</span>
+          <span class="filter-chip__count">{{ riskCounters()[filter.key] }}</span>
+        </button>
+      }
+    </div>
+  </div>
+
+  @if (error()) {
+    <div class="alert alert--error" role="alert">
+      <div class="alert__content">
+        <mat-icon aria-hidden="true">error</mat-icon>
+        <span>{{ error() }}</span>
+      </div>
+      <button type="button" class="alert__action" (click)="refresh()">Thử lại</button>
+    </div>
+  }
+
+  @if (loading()) {
+    <div class="loading-state" aria-live="polite">
+      <div class="loading-state__spinner"></div>
+      <p>Đang tải danh sách khách thuê...</p>
+    </div>
+  } @else {
+    @if (listViewModels().length > 0) {
+      <ul class="renter-list">
+        @for (item of listViewModels(); track item.record.renterId) {
+          <li class="renter-card">
+            <div class="renter-card__header">
+              <div class="renter-card__avatar" aria-hidden="true">{{ item.initials }}</div>
+              <div class="renter-card__identity">
+                <h2 class="renter-card__name">{{ item.nameDisplay }}</h2>
+                <p class="renter-card__identifier">Mã khách: {{ item.identifierDisplay }}</p>
+              </div>
+              @if (item.riskBadge; as badge) {
+                <span
+                  class="badge"
+                  [class.badge--success]="badge.tone === 'success'"
+                  [class.badge--info]="badge.tone === 'info'"
+                  [class.badge--danger]="badge.tone === 'danger'"
+                  [class.badge--pending]="badge.tone === 'pending'"
+                >
+                  {{ badge.text }}
+                </span>
+              }
+            </div>
+
+            <div class="renter-card__body">
+              <div class="renter-card__section">
+                <span class="renter-card__section-label">Số bằng lái</span>
+                <span class="renter-card__section-value">{{ item.licenseDisplay }}</span>
+              </div>
+              <div class="renter-card__section">
+                <span class="renter-card__section-label">Ngày sinh</span>
+                <span class="renter-card__section-value">{{ item.dateOfBirthDisplay }}</span>
+              </div>
+              <div class="renter-card__section">
+                <span class="renter-card__section-label">Tuổi</span>
+                <span class="renter-card__section-value">{{ item.ageDisplay }}</span>
+              </div>
+              <div class="renter-card__section renter-card__section--wide">
+                <span class="renter-card__section-label">Địa chỉ</span>
+                <span class="renter-card__section-value">{{ item.addressDisplay }}</span>
+              </div>
+              <div class="renter-card__section">
+                <span class="renter-card__section-label">Điểm rủi ro</span>
+                <span class="renter-card__section-value">{{ item.riskScoreDisplay }}</span>
+              </div>
+            </div>
+          </li>
+        }
+      </ul>
+    } @else {
+      <div class="empty-state">
+        <mat-icon aria-hidden="true">group_off</mat-icon>
+        <h2>Không tìm thấy khách thuê</h2>
+        <p>Hãy điều chỉnh bộ lọc hoặc xóa từ khóa tìm kiếm.</p>
+        <button type="button" (click)="clearSearch()">Xóa tìm kiếm</button>
+      </div>
+    }
+  }
+</section>

--- a/src/app/features/staff/renter-management/renter-management.scss
+++ b/src/app/features/staff/renter-management/renter-management.scss
@@ -1,0 +1,370 @@
+:host {
+  display: block;
+  padding: 2.5rem 0;
+  color: var(--mat-sys-on-surface, #0e1114);
+}
+
+.renter-management {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.page-header__titles {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.page-header__title {
+  margin: 0;
+  font-size: clamp(1.75rem, 2vw, 2rem);
+  font-weight: 600;
+  color: inherit;
+}
+
+.page-header__subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--mat-sys-on-surface-variant, #4b5563);
+}
+
+.refresh-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.2rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: var(--mat-sys-primary, #2563eb);
+  color: var(--mat-sys-on-primary, #fff);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.refresh-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.refresh-button:hover:enabled {
+  background: color-mix(in srgb, var(--mat-sys-primary, #2563eb) 88%, #fff);
+  box-shadow: 0 8px 16px rgb(37 99 235 / 25%);
+  transform: translateY(-1px);
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.toolbar__search {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1 1 320px;
+  padding: 0.6rem 0.8rem;
+  border-radius: 999px;
+  background: var(--mat-sys-surface, #fff);
+  box-shadow: 0 8px 24px rgb(15 23 42 / 12%);
+}
+
+.toolbar__input {
+  flex: 1 1 auto;
+  border: 0;
+  background: transparent;
+  font-size: 0.95rem;
+  color: inherit;
+}
+
+.toolbar__input:focus {
+  outline: none;
+}
+
+.toolbar__clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border: 0;
+  border-radius: 999px;
+  background: rgb(15 23 42 / 8%);
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.toolbar__clear:hover {
+  background: rgb(15 23 42 / 16%);
+}
+
+.toolbar__filters {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.45rem 0.9rem;
+  border: 1px solid var(--mat-sys-outline-variant, #d1d5db);
+  border-radius: 999px;
+  background: var(--mat-sys-surface, #fff);
+  color: var(--mat-sys-on-surface-variant, #4b5563);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border 0.2s ease;
+}
+
+.filter-chip:hover {
+  background: rgb(37 99 235 / 10%);
+  border-color: transparent;
+  color: var(--mat-sys-primary, #2563eb);
+}
+
+.filter-chip--active {
+  background: rgb(37 99 235 / 14%);
+  border-color: transparent;
+  color: var(--mat-sys-primary, #2563eb);
+}
+
+.filter-chip__label {
+  font-size: 0.9rem;
+}
+
+.filter-chip__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  padding: 0 0.45rem;
+  border-radius: 999px;
+  background: var(--mat-sys-primary, #2563eb);
+  color: var(--mat-sys-on-primary, #fff);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.alert {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  border-radius: 0.75rem;
+  background: rgb(220 38 38 / 12%);
+  color: rgb(185 28 28);
+}
+
+.alert__content {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.alert__action {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.loading-state {
+  display: grid;
+  justify-items: center;
+  gap: 0.75rem;
+  padding: 2rem 0;
+  color: var(--mat-sys-on-surface-variant, #4b5563);
+}
+
+.loading-state__spinner {
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 3px solid rgb(37 99 235 / 16%);
+  border-top-color: var(--mat-sys-primary, #2563eb);
+  border-radius: 50%;
+  animation: renter-spinner 1s linear infinite;
+}
+
+@keyframes renter-spinner {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.renter-list {
+  display: grid;
+  gap: 1rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.renter-card {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  background: var(--mat-sys-surface, #fff);
+  box-shadow: 0 16px 32px rgb(15 23 42 / 12%);
+}
+
+.renter-card__header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.renter-card__avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  background: rgb(37 99 235 / 16%);
+  color: var(--mat-sys-primary, #2563eb);
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.renter-card__identity {
+  flex: 1 1 auto;
+}
+
+.renter-card__name {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: inherit;
+}
+
+.renter-card__identifier {
+  margin: 0.1rem 0 0;
+  font-size: 0.9rem;
+  color: var(--mat-sys-on-surface-variant, #4b5563);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.badge--success {
+  background: rgb(22 163 74 / 14%);
+  color: rgb(21 128 61);
+}
+
+.badge--info {
+  background: rgb(37 99 235 / 14%);
+  color: var(--mat-sys-primary, #2563eb);
+}
+
+.badge--danger {
+  background: rgb(239 68 68 / 16%);
+  color: rgb(185 28 28);
+}
+
+.badge--pending {
+  background: rgb(234 179 8 / 18%);
+  color: rgb(161 98 7);
+}
+
+.renter-card__body {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.85rem 1.5rem;
+}
+
+.renter-card__section {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.renter-card__section--wide {
+  grid-column: 1 / -1;
+}
+
+.renter-card__section-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--mat-sys-on-surface-variant, #6b7280);
+}
+
+.renter-card__section-value {
+  font-size: 0.95rem;
+  color: inherit;
+}
+
+.empty-state {
+  display: grid;
+  justify-items: center;
+  gap: 0.75rem;
+  padding: 3rem 1rem;
+  border-radius: 1rem;
+  background: var(--mat-sys-surface, #fff);
+  color: var(--mat-sys-on-surface-variant, #4b5563);
+  text-align: center;
+}
+
+.empty-state mat-icon {
+  font-size: 3rem;
+  width: 3rem;
+  height: 3rem;
+}
+
+.empty-state button {
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: var(--mat-sys-primary, #2563eb);
+  color: var(--mat-sys-on-primary, #fff);
+  font-weight: 500;
+  cursor: pointer;
+}
+
+@media (max-width: 600px) {
+  .page-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .refresh-button {
+    align-self: flex-start;
+  }
+
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .toolbar__filters {
+    justify-content: flex-start;
+  }
+}

--- a/src/app/features/staff/renter-management/renter-management.ts
+++ b/src/app/features/staff/renter-management/renter-management.ts
@@ -1,0 +1,296 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { take } from 'rxjs';
+import { RentersService, StaffRenterRecord } from '../../../core-logic/renters/renters.service';
+
+interface RiskBadge {
+  readonly text: string;
+  readonly tone: 'success' | 'info' | 'danger' | 'pending';
+}
+
+type RiskCategory = 'low' | 'medium' | 'high' | 'unknown';
+
+type RiskFilterKey = 'all' | RiskCategory;
+
+interface RiskFilterDescriptor {
+  readonly key: RiskFilterKey;
+  readonly label: string;
+}
+
+interface RenterListItem {
+  readonly record: StaffRenterRecord;
+  readonly nameDisplay: string;
+  readonly identifierDisplay: string;
+  readonly licenseDisplay: string;
+  readonly dateOfBirthDisplay: string;
+  readonly ageDisplay: string;
+  readonly addressDisplay: string;
+  readonly riskScoreDisplay: string;
+  readonly riskBadge?: RiskBadge;
+  readonly initials: string;
+}
+
+const RISK_FILTERS: readonly RiskFilterDescriptor[] = [
+  { key: 'all', label: 'Tất cả' },
+  { key: 'high', label: 'Nguy cơ cao' },
+  { key: 'medium', label: 'Nguy cơ trung bình' },
+  { key: 'low', label: 'Nguy cơ thấp' },
+  { key: 'unknown', label: 'Chưa đánh giá' },
+] as const;
+
+const RISK_BADGES: Record<RiskCategory, RiskBadge> = {
+  low: { text: 'Nguy cơ thấp', tone: 'success' },
+  medium: { text: 'Nguy cơ trung bình', tone: 'info' },
+  high: { text: 'Nguy cơ cao', tone: 'danger' },
+  unknown: { text: 'Chưa đánh giá', tone: 'pending' },
+};
+
+@Component({
+  selector: 'app-renter-management',
+  imports: [MatIconModule],
+  templateUrl: './renter-management.html',
+  styleUrl: './renter-management.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class RenterManagement {
+  private readonly rentersService = inject(RentersService);
+
+  readonly searchTerm = signal('');
+  readonly riskFilter = signal<RiskFilterKey>('all');
+
+  readonly loading = computed(() => this.rentersService.staffRentersLoading());
+  readonly error = computed(() => this.rentersService.staffRentersError());
+  private readonly allRecords = computed(() => this.rentersService.staffRenters());
+  private readonly normalizedSearch = computed(() => this.searchTerm().trim().toLowerCase());
+
+  readonly riskFilters = RISK_FILTERS;
+
+  readonly riskCounters = computed<Record<RiskFilterKey, number>>(() => {
+    const counters: Record<RiskFilterKey, number> = {
+      all: 0,
+      low: 0,
+      medium: 0,
+      high: 0,
+      unknown: 0,
+    };
+
+    for (const record of this.allRecords()) {
+      const category = this._categorizeRisk(record.riskScore);
+      counters[category] += 1;
+      counters.all += 1;
+    }
+
+    return counters;
+  });
+
+  private readonly filteredRecords = computed(() => {
+    const filter = this.riskFilter();
+    const query = this.normalizedSearch();
+
+    return this.allRecords().filter((record) => {
+      if (!this._matchesSearch(record, query)) {
+        return false;
+      }
+
+      if (filter === 'all') {
+        return true;
+      }
+
+      return this._categorizeRisk(record.riskScore) === filter;
+    });
+  });
+
+  readonly listViewModels = computed<RenterListItem[]>(() =>
+    this.filteredRecords()
+      .map((record) => {
+        const category = this._categorizeRisk(record.riskScore);
+        const badge = RISK_BADGES[category];
+
+        return {
+          record,
+          nameDisplay: this._resolveName(record),
+          identifierDisplay: record.renterId,
+          licenseDisplay: record.driverLicenseNo ?? 'Không có thông tin bằng lái',
+          dateOfBirthDisplay: this._formatDate(record.dateOfBirth),
+          ageDisplay: this._formatAge(record.dateOfBirth),
+          addressDisplay: record.address ?? 'Không có địa chỉ',
+          riskScoreDisplay: this._formatRiskScore(record.riskScore),
+          riskBadge: badge,
+          initials: this._buildInitials(record),
+        } satisfies RenterListItem;
+      })
+      .sort((first, second) => this._sortByRiskThenName(first.record, second.record)),
+  );
+
+  private readonly dateFormatter = new Intl.DateTimeFormat('vi-VN', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+
+  constructor() {
+    this.refresh();
+  }
+
+  refresh(): void {
+    this.rentersService.loadStaffRenters().pipe(take(1)).subscribe();
+  }
+
+  onSearchInput(event: Event): void {
+    const target = event.target as HTMLInputElement | null;
+    const value = target?.value ?? '';
+    if (value === this.searchTerm()) {
+      return;
+    }
+    this.searchTerm.set(value);
+  }
+
+  clearSearch(): void {
+    if (this.searchTerm().length === 0) {
+      return;
+    }
+    this.searchTerm.set('');
+  }
+
+  onRiskFilterChange(filter: RiskFilterKey): void {
+    if (this.riskFilter() === filter) {
+      return;
+    }
+    this.riskFilter.set(filter);
+  }
+
+  private _matchesSearch(record: StaffRenterRecord, query: string): boolean {
+    if (query.length === 0) {
+      return true;
+    }
+
+    const haystacks: readonly string[] = [
+      record.userName ?? '',
+      record.driverLicenseNo ?? '',
+      record.address ?? '',
+      record.renterId,
+    ];
+
+    for (const value of haystacks) {
+      if (value.toLowerCase().includes(query)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private _categorizeRisk(score: number | undefined): RiskCategory {
+    if (typeof score !== 'number' || Number.isNaN(score)) {
+      return 'unknown';
+    }
+
+    if (score >= 70) {
+      return 'high';
+    }
+
+    if (score >= 40) {
+      return 'medium';
+    }
+
+    return 'low';
+  }
+
+  private _resolveName(record: StaffRenterRecord): string {
+    if (record.userName && record.userName.length > 0) {
+      return record.userName;
+    }
+
+    return `Khách thuê ${record.renterId.slice(-4)}`;
+  }
+
+  private _formatDate(value: string | undefined): string {
+    if (!value) {
+      return '--';
+    }
+
+    const timestamp = Date.parse(value);
+    if (Number.isNaN(timestamp)) {
+      return '--';
+    }
+
+    return this.dateFormatter.format(timestamp);
+  }
+
+  private _formatAge(value: string | undefined): string {
+    if (!value) {
+      return '--';
+    }
+
+    const birthTime = Date.parse(value);
+    if (Number.isNaN(birthTime)) {
+      return '--';
+    }
+
+    const now = Date.now();
+    if (Number.isNaN(now)) {
+      return '--';
+    }
+
+    const diff = now - birthTime;
+    const age = Math.floor(diff / (365.25 * 24 * 60 * 60 * 1000));
+    if (age < 0 || age > 120) {
+      return '--';
+    }
+
+    return `${age} tuổi`;
+  }
+
+  private _formatRiskScore(score: number | undefined): string {
+    if (typeof score !== 'number' || Number.isNaN(score)) {
+      return '--';
+    }
+
+    return `${Math.round(score)} / 100`;
+  }
+
+  private _buildInitials(record: StaffRenterRecord): string {
+    if (record.userName && record.userName.trim().length > 0) {
+      const parts = record.userName
+        .trim()
+        .split(' ')
+        .map((part) => part.trim())
+        .filter((part) => part.length > 0);
+      const initials = parts
+        .map((part) => part.charAt(0))
+        .filter((char) => char.length > 0)
+        .slice(0, 2)
+        .join('');
+      if (initials.length > 0) {
+        return initials.toUpperCase();
+      }
+    }
+
+    if (record.driverLicenseNo && record.driverLicenseNo.length > 0) {
+      return record.driverLicenseNo.slice(-2).toUpperCase();
+    }
+
+    return record.renterId.slice(-2).toUpperCase();
+  }
+
+  private _sortByRiskThenName(first: StaffRenterRecord, second: StaffRenterRecord): number {
+    const firstCategory = this._categorizeRisk(first.riskScore);
+    const secondCategory = this._categorizeRisk(second.riskScore);
+
+    const rank: Record<RiskCategory, number> = {
+      high: 3,
+      medium: 2,
+      low: 1,
+      unknown: 0,
+    };
+
+    const rankDiff = rank[secondCategory] - rank[firstCategory];
+    if (rankDiff !== 0) {
+      return rankDiff;
+    }
+
+    const firstName = this._resolveName(first);
+    const secondName = this._resolveName(second);
+    return firstName.localeCompare(secondName);
+  }
+}

--- a/src/app/features/staff/staff.routes.ts
+++ b/src/app/features/staff/staff.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { StaffDashboard } from './staff-dashboard/staff-dashboard';
 import { RentalManagement } from './rental-management/rental-management';
 import { VehicleManagement } from './vehicle-management/vehicle-management';
+import { RenterManagement } from './renter-management/renter-management';
 
 export default [
   {
@@ -16,6 +17,10 @@ export default [
   {
     path: 'vehicles',
     component: VehicleManagement,
+  },
+  {
+    path: 'renters',
+    component: RenterManagement,
   },
   {
     path: 'rentals',

--- a/src/app/layout/layout.ts
+++ b/src/app/layout/layout.ts
@@ -87,7 +87,7 @@ export class LayoutComponent {
     staff: [
       { name: 'Booking Management', href: '/staff/bookings', current: false, icon: 'event_note' },
       { name: 'Quản lý xe', href: '/staff/vehicles', current: false, icon: 'car_rental' },
-      { name: 'Quản lý khách hàng', href: '/staff/customers', current: false, icon: 'group' },
+      { name: 'Renters Management', href: '/staff/renters', current: false, icon: 'group' },
       { name: 'Rental Management', href: '/staff/rentals', current: false, icon: 'assignment' },
       { name: 'Báo cáo', href: '/staff/reports', current: false, icon: 'analytics' },
     ],


### PR DESCRIPTION
## Summary
- add a signal-backed `RentersService` that loads renter profiles from `/api/Staff/renters`
- build a renters management staff view with search, risk filtering, and accessible cards
- expose the new view at `/staff/renters` and update staff navigation to link to it

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691355eb952c8320b716c22c613e30b4)